### PR TITLE
Use ContextMenuHookLib for the dev tool context menu

### DIFF
--- a/ReferenceFinder/ReferenceFinder.cs
+++ b/ReferenceFinder/ReferenceFinder.cs
@@ -7,6 +7,8 @@ using HarmonyLib;
 using ResoniteModLoader;
 using System.Reflection;
 
+using ContextMenuHookLib;
+
 #if DEBUG
 using ResoniteHotReloadLib;
 #endif
@@ -24,6 +26,10 @@ public class ReferenceFinderMod : ResoniteMod
 
 	private static Harmony harmony = new Harmony("owo.Nytra.ReferenceFinderWizard");
 	private static Type? nestedAsyncPressedType;
+
+	private static LocaleString menuItemLabel = "Find references".AsLocaleKey();
+	private static colorX menuItemColor = RadiantUI_Constants.Hero.RED;
+	private static Uri menuItemIcon = OfficialAssets.Graphics.Icons.Dash.MagnifyingGlass;
 
 	public override void OnEngineInit()
 	{
@@ -694,15 +700,13 @@ public class ReferenceFinderMod : ResoniteMod
 			?? ima.Slot.GetComponentInParents<UserInspector>()?.Slot
 			?? ima.Slot.GetComponentInParents<GenericUIContainer>()?.Slot;
 
-		LocaleString label = "Find references".AsLocaleKey();
-		colorX? col = RadiantUI_Constants.Neutrals.LIGHT;
 		ContextMenu menu = ima.LocalUser.GetUserContextMenu();
 		if (menu is null)
 		{
 			Error($"Context menu is null in InspectorMemberActions patch!");
 			return;
 		}
-		ContextMenuItem item = menu.AddItem(in label, (Uri?)null, in col);
+		ContextMenuItem item = menu.AddItem(in menuItemLabel, menuItemIcon, menuItemColor);
 		item.Button.LocalPressed += (btn, data) => OpenWizardOnMember(btn, data, elem, src, menu);
 	}
 
@@ -732,28 +736,14 @@ public class ReferenceFinderMod : ResoniteMod
 		});
 	}
 
-	[HarmonyPatch(typeof(DevTool), nameof(DevTool.OnSecondaryPress))]
-	public static class Patch_DevTool
+	[ContextMenuHook(typeof(DevTool), nameof(DevTool.OnSecondaryPress))]
+	public static IEnumerable<MenuItem> DevToolSecondaryItem(DevTool __instance)
 	{
-		static bool Prefix(DevTool __instance)
-		{
-			IWorldElement elem = __instance.GetGrabbedReference();
-			if (elem != null) {
-				__instance.StartTask(async delegate {
-					var cm = await __instance.LocalUser.OpenContextMenu(__instance, __instance.Slot);
-					if (cm is null)
-					{
-						Error("Context menu is null in Dev Tool patch!");
-						return;
-					}
-					LocaleString label = "Find references".AsLocaleKey();
-					colorX? col = RadiantUI_Constants.Neutrals.LIGHT;
-					ContextMenuItem item = cm.AddItem(in label, (Uri?)null, in col);
-					item.Button.LocalPressed += (btn, data) => OpenWizardOnMember(btn, data, elem, null, cm, true);
-				});
-				return false;
-			}
-			return true;
+		IWorldElement elem = __instance.GetGrabbedReference();
+		if (elem != null) {
+			var iinfo = new MenuItem(__instance, menuItemLabel, menuItemIcon, menuItemColor);
+			iinfo.LocalPressed.Add((btn, data, cm, _) => OpenWizardOnMember(btn, data, elem, null, cm, true));
+			yield return iinfo;
 		}
 	}
 }

--- a/ReferenceFinder/ReferenceFinder.csproj
+++ b/ReferenceFinder/ReferenceFinder.csproj
@@ -43,6 +43,9 @@
 		<Reference Include="HarmonyLib">
 			<HintPath>$(ResonitePath)/rml_libs/0Harmony.dll</HintPath>
 		</Reference>
+		<Reference Include="ContextMenuHookLib">
+			<HintPath>$(ResonitePath)/rml_mods/ContextMenuHookLib.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
the time has come where [another mod I made](https://git.unix.dog/yosh/ResoniteCollectionEditor) wants to patch the same function for adding a context menu when pressing secondary on the dev tip

when both that mod and this mod use a prefix patch for that, then if either of them return false, the other patch is not run. If a postfix patch is used, then the `TryOpenGizmo()` function is run, which isn't really the best UX

I made [a library that resolves this](https://git.unix.dog/yosh/ResoniteContextMenuHookLib) and now both this mod and my mod can add their items to the same function prefix. I also took the time to make the menu item pop out a bit more. it's red now and has the search icon from the dash

I've tested this myself and everything seems fine